### PR TITLE
Implement recording using VPN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,6 @@ src/frontend/mm-delayshell-port-forwarded
 src/frontend/mm-http1-proxyreplay
 src/frontend/mm-per-packet-delay-replay
 src/frontend/mm-phone-webrecord
-
+src/frontend/mm-http1-proxyreplay-no-pac
+src/frontend/mm-http1-proxyreplay-no-proxy
+src/frontend/mm-phone-webrecord-using-vpn

--- a/src/frontend/Makefile.am
+++ b/src/frontend/Makefile.am
@@ -41,6 +41,11 @@ mm_phone_webrecord_SOURCES = phone_recordshell.cc squid_proxy.hh squid_proxy.cc
 mm_phone_webrecord_LDADD = -lrt ../httpserver/libhttpserver.a ../http/libhttp.a ../protobufs/libhttprecordprotos.a ../util/libutil.a $(protobuf_LIBS) $(libcrypto_LIBS) $(libssl_LIBS)
 mm_phone_webrecord_LDFLAGS = -pthread
 
+bin_PROGRAMS += mm-phone-webrecord-using-vpn
+mm_phone_webrecord_using_vpn_SOURCES = phone_recordshell_using_vpn.cc 
+mm_phone_webrecord_using_vpn_LDADD = -lrt ../httpserver/libhttpserver.a ../http/libhttp.a ../protobufs/libhttprecordprotos.a ../util/libutil.a $(protobuf_LIBS) $(libcrypto_LIBS) $(libssl_LIBS)
+mm_phone_webrecord_using_vpn_LDFLAGS = -pthread
+
 bin_PROGRAMS += mm-delayshell-port-forwarded
 mm_delayshell_port_forwarded_SOURCES = delayshell_with_forwarding.cc delay_queue.hh delay_queue.cc
 mm_delayshell_port_forwarded_LDADD = -lrt ../util/libutil.a ../packet/libpacket.a
@@ -108,5 +113,7 @@ install-exec-hook:
 	chmod u+s $(DESTDIR)$(bindir)/mm-delayshell-port-forwarded
 	chown root $(DESTDIR)$(bindir)/mm-phone-webrecord
 	chmod u+s $(DESTDIR)$(bindir)/mm-phone-webrecord
+	chown root $(DESTDIR)$(bindir)/mm-phone-webrecord-using-vpn
+	chmod u+s $(DESTDIR)$(bindir)/mm-phone-webrecord-using-vpn
 	chown root $(DESTDIR)$(bindir)/mm-per-packet-delay-replay
 	chmod u+s $(DESTDIR)$(bindir)/mm-per-packet-delay-replay

--- a/src/frontend/phone_recordshell_using_vpn.cc
+++ b/src/frontend/phone_recordshell_using_vpn.cc
@@ -1,0 +1,178 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <linux/if.h>
+#include <net/route.h>
+
+#include "forwarder.hh"
+#include "nat.hh"
+#include "util.hh"
+#include "interfaces.hh"
+#include "address.hh"
+#include "dns_proxy.hh"
+#include "http_proxy.hh"
+#include "netdevice.hh"
+#include "event_loop.hh"
+#include "socketpair.hh"
+#include "config.h"
+#include "backing_store.hh"
+#include "exception.hh"
+#include "vpn.hh"
+
+using namespace std;
+
+int main( int argc, char *argv[] )
+{
+    try {
+        /* clear environment */
+        char **user_environment = environ;
+        environ = nullptr;
+
+        check_requirements( argc, argv );
+
+        if ( argc < 2 ) {
+            throw runtime_error( "Usage: " + string( argv[ 0 ] ) + " directory" );
+        }
+
+        /* Make sure directory ends with '/' so we can prepend directory to file name for storage */
+        string directory( argv[ 1 ] );
+
+        if ( directory.empty() ) {
+            throw runtime_error( string( argv[ 0 ] ) + ": directory name must be non-empty" );
+        }
+
+        if ( directory.back() != '/' ) {
+            directory.append( "/" );
+        }
+
+        const Address nameserver = first_nameserver();
+
+        /* set egress and ingress ip addresses */
+        Address egress_addr, ingress_addr;
+        tie( egress_addr, ingress_addr ) = two_unassigned_addresses();
+
+        /* make pair of devices */
+        string egress_name = "veth-" + to_string( getpid() ), ingress_name = "veth-i" + to_string( getpid() );
+        VirtualEthernetPair veth_devices( egress_name, ingress_name );
+
+        /* bring up egress */
+        assign_address( egress_name, egress_addr, ingress_addr );
+        cout << "DNS Outside Nameserver: " << egress_addr.str() << endl;
+
+        /* create DNS proxy */
+        DNSProxy dns_outside( egress_addr, nameserver, nameserver );
+
+        /* set up NAT between egress and eth0 */
+        NAT nat_rule( ingress_addr );
+
+        /* set up http proxy for tcp */
+        HTTPProxy http_proxy( egress_addr );
+
+        /* set up dnat */
+        DNAT dnat( http_proxy.tcp_listener().local_address(), egress_name );
+        DNAT openvpn( Address(ingress_addr.ip(), 1194), "udp", 1194 );
+
+        /* prepare event loop */
+        EventLoop outer_event_loop;
+
+        /* Fork */
+        {
+            /* Make pipe for start signal */
+            auto pipe = UnixDomainSocket::make_pair();
+
+            ChildProcess container_process( "recordshell", [&]() {
+                    /* wait for the go signal */
+                    pipe.second.read();
+
+                    /* bring up localhost */
+                    interface_ioctl( SIOCSIFFLAGS, "lo",
+                                     [] ( ifreq &ifr ) { ifr.ifr_flags = IFF_UP; } );
+
+                    /* bring up veth device */
+                    assign_address( ingress_name, ingress_addr, egress_addr );
+
+                    /* create default route */
+                    rtentry route;
+                    zero( route );
+
+                    route.rt_gateway = egress_addr.to_sockaddr();
+                    route.rt_dst = route.rt_genmask = Address().to_sockaddr();
+                    route.rt_flags = RTF_UP | RTF_GATEWAY;
+
+                    SystemCall( "ioctl SIOCADDRT", ioctl( UDPSocket().fd_num(), SIOCADDRT, &route ) );
+
+                    /* create DNS proxy if nameserver address is local */
+                    auto dns_inside = DNSProxy::maybe_proxy( nameserver,
+                                                             dns_outside.udp_listener().local_address(),
+                                                             dns_outside.tcp_listener().local_address() );
+
+                    cout << "DNS Inside Nameserver: " << nameserver.str() << endl;
+                    string path_to_security_files = "/etc/openvpn/";
+                    VPN vpn(path_to_security_files, ingress_addr);
+                    vector<string> command = vpn.start_command();
+
+                    // For debugging purposes.
+                    // for (auto i = vpn_command.begin(); i != vpn_command.end(); i++) {
+                    //   cout << *i << ' ';
+                    // }
+                    // cout << endl;
+                    // vector<string> command = { "bash" };
+
+                    /* forward all packets from tun0 (OpenVPN interface) to the ingress interface */
+                    Forwarder forwarder("tun0", ingress_name);
+
+                    /* Fork again after dropping root privileges */
+                    drop_privileges();
+
+                    /* prepare child's event loop */
+                    EventLoop shell_event_loop;
+
+                    shell_event_loop.add_child_process( join( command ), [&]() {
+                            /* restore environment and tweak prompt */
+                            environ = user_environment;
+                            prepend_shell_prefix( "[record] " );
+
+                            return ezexec( command, true );
+                        } );
+
+                    if ( dns_inside ) {
+                        cout << "DNS Inside not NULL" << endl;
+                        dns_inside->register_handlers( shell_event_loop );
+                    }
+
+                    return shell_event_loop.loop();
+                }, true ); /* new network namespace */
+
+            /* give ingress to container */
+            run( { IP, "link", "set", "dev", ingress_name, "netns", to_string( container_process.pid() ) } );
+            veth_devices.set_kernel_will_destroy();
+
+            /* tell ChildProcess it's ok to proceed */
+            pipe.first.write( "x" );
+
+            /* now that we have its pid, move container process to event loop */
+            outer_event_loop.add_child_process( move( container_process ) );
+        }
+
+        /* do the actual recording in a different unprivileged child */
+        outer_event_loop.add_child_process( "recorder", [&]() {
+                drop_privileges();
+
+                make_directory( directory );
+
+                /* set up backing store to save to disk */
+                HTTPDiskStore disk_backing_store( directory );
+
+                EventLoop recordr_event_loop;
+                dns_outside.register_handlers( recordr_event_loop );
+                http_proxy.register_handlers( recordr_event_loop, disk_backing_store );
+                return recordr_event_loop.loop();
+            } );
+
+        return outer_event_loop.loop();
+    } catch ( const exception & e ) {
+        print_exception( e );
+        return EXIT_FAILURE;
+    }
+}

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -5,7 +5,7 @@ noinst_LIBRARIES = libutil.a
 
 libutil_a_SOURCES = exception.hh ezio.cc ezio.hh                               \
         file_descriptor.hh file_descriptor.cc netdevice.cc netdevice.hh        \
-	timestamp.cc timestamp.hh                                              \
+				timestamp.cc timestamp.hh                                              \
         child_process.hh child_process.cc signalfd.hh signalfd.cc              \
         socket.cc socket.hh address.cc address.hh                              \
         system_runner.hh system_runner.cc nat.hh nat.cc                        \
@@ -14,4 +14,5 @@ libutil_a_SOURCES = exception.hh ezio.cc ezio.hh                               \
         poller.hh poller.cc bytestream_queue.hh bytestream_queue.cc            \
         event_loop.hh event_loop.cc                                            \
         temp_file.hh temp_file.cc dns_server.hh dns_server.cc                  \
-        socketpair.hh socketpair.cc vpn.cc vpn.hh pac_file.cc pac_file.hh
+        socketpair.hh socketpair.cc vpn.cc vpn.hh pac_file.cc pac_file.hh 		 \
+				forwarder.cc forwarder.hh

--- a/src/util/forwarder.cc
+++ b/src/util/forwarder.cc
@@ -1,0 +1,51 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/* RAII class to forward packets from one interface to another. */
+
+#include <unistd.h>
+#include <iostream>
+
+#include "forwarder.hh"
+#include "exception.hh"
+#include "config.h"
+
+using namespace std;
+
+Forwarder::Forwarder( const string from, const string to ) :
+    first_forward_command({"-i", from, "-o", to, "-j", "ACCEPT"}),
+    second_forward_command({"-i", to, "-o", from, "-m", "state", "--state", "ESTABLISHED,RELATED",  "-j", "ACCEPT"}),
+    third_forward_command({"POSTROUTING", "-o", to, "-j", "MASQUERADE" })
+{
+    // In order to forward packets from one interface to another, we need
+    // the following iptables commands:
+    //  $ sudo iptables -A FORWARD -i [from] -o [to] -j ACCEPT
+    //  $ sudo iptables -A FORWARD -i [to] -o [from] -m state --state ESTABLISHED,RELATED -j ACCEPT
+    //  $ sudo iptables -t nat -A POSTROUTING -o [to] -j MASQUERADE
+    vector<string> first_forward = {IPTABLES, "-w", "-A", "FORWARD"};
+    first_forward.insert(first_forward.end(), this->first_forward_command.begin(), this->first_forward_command.end());
+    run(first_forward);
+
+    vector<string> second_forward = {IPTABLES, "-w", "-A", "FORWARD"};
+    second_forward.insert(second_forward.end(), this->second_forward_command.begin(), this->second_forward_command.end());
+    run(second_forward);
+
+    vector<string> third_forward = {IPTABLES, "-w", "-t", "nat", "-A"};
+    third_forward.insert(third_forward.end(), this->third_forward_command.begin(), this->third_forward_command.end());
+    run(third_forward);
+}
+
+Forwarder::~Forwarder() {
+    try {
+      vector<string> first_remove_command = {IPTABLES, "-w", "-D", "FORWARD"};
+      first_remove_command.insert(first_remove_command.end(), this->first_forward_command.begin(), this->first_forward_command.end());
+
+      vector<string> second_remove_command = {IPTABLES, "-w", "-D", "FORWARD"};
+      second_remove_command.insert(second_remove_command.end(), this->second_forward_command.begin(), this->second_forward_command.end());
+
+      vector< string > third_remove_command = { IPTABLES, "-w", "-t", "nat", "-D" };
+      third_remove_command.insert(third_remove_command.end(), this->third_forward_command.begin(), this->third_forward_command.end());
+    } catch ( const exception & e ) { /* don't throw from destructor */
+        print_exception( e );
+    }
+
+}

--- a/src/util/forwarder.hh
+++ b/src/util/forwarder.hh
@@ -1,0 +1,26 @@
+/* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+#ifndef FORWARDER_HH
+#define FORWARDER_HH
+
+/* Packet Forwarder */
+
+#include <string>
+
+#include "system_runner.hh"
+#include "address.hh"
+
+/* RAII class to forward packets from one interface to another. */
+class Forwarder
+{
+private:
+    std::vector<std::string> first_forward_command;
+    std::vector<std::string> second_forward_command;
+    std::vector<std::string> third_forward_command;
+
+public:
+    Forwarder( const std::string from, const std::string to );
+    ~Forwarder();
+};
+
+#endif /* FORWARDER_HH */


### PR DESCRIPTION
This PR implements a new recordshell for actual mobile device that uses VPN. The issue with the regular recordshell is that the browser can fetch an object that does not belong to a mobile viewport. This can also be fixed by emulating a mobile device, but using an actual device is cleaner. Following are summary of things implemented:

* Shell that uses VPN. Given this PR, Squid is not needed anymore.
* `Forwarder` utility in the lib. VPN creates a new interface, but that does not play well with Mahimahi setup because Mahimahi also creates another interface for outgoing traffic. Forwarder forwards packets from one interface to another.